### PR TITLE
Docker + Nginx + DuckDNS: HTTP-only site up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 flask/__pycache__
 flask/pyvenv.cfg
 flask/lib/
+flask/lib64/
 flask/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,20 @@
-.PHONY: flask-dev flask-prod
+.PHONY: flask-dev uwsgi-dev docker-build docker-up docker-down
+
+SHELL=/usr/bin/bash
 
 FLASK_DEV_PORT=8000
-FLASK_PROD_PORT=8000
 
 flask-dev:
 	cd flask && source bin/activate && flask --app website run --debug --port $(FLASK_DEV_PORT)
 
-flask-prod:
-	cd flask && source bin/activate && uwsgi --http 127.0.0.1:$(FLASK_PROD_PORT) --master -p 4 -w website:app
+uwsgi-dev:
+	cd flask && source bin/activate && uwsgi --http 127.0.0.1:$(FLASK_DEV_PORT) --master -p 4 -w website:app
+
+docker-build:
+	cd flask && sudo docker build -t tech4taxes-website .
+
+docker-up:
+	sudo docker compose up -d
+
+docker-down:
+	sudo docker compose down

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ We use a python virtualenv in the flask/ folder to run the flask app, set up wit
  make flask-dev
 ```
 
+## docker setup
+For docker, I've included a few make targets, notably `docker-build` and `docker-up`.
+All the make targets want to be called from the project root (website/) but technically docker build wants to run in the flask/ folder, since that's where
+the actual Dockerfile is that builds the image. In the Makefile, I believe I call it `tech4taxes-website` but technically if you want to name it something else go crazy,
+just be consistent with the image name used in the docker-compose.yml file.
+
+Of note for the docker setup (it's using jwilder/nginx-proxy) - it NEEDS dns to be set up, or it NEEDS for the Host: {sfdasdfa} header to be set in any http requests you send to localhost:80 or 443.
+The official thing recommends curl when testing and I also do since doing anything else is super annoying:
+`curl -H 'Host: tech4taxes.duckdns.org' localhost:80`
+
+
+I don't have any actual recommendation to use the docker setup for development. So far it's just for handling proxying and SSL (eventually). It's a pain otherwise, so feel free to not use it.
 
 ## References / Resources
 - https://flask.palletsprojects.com/en/stable/quickstart/
@@ -32,3 +44,12 @@ Regarding NGINX/LetsEncrypt/Docker -
 I still haven't decided/figured out how to do CSS/assets/javascript (for data vis), but I expect it'll look something like:
 - https://medium.com/@jannelson36/build-engaging-and-interactive-charts-using-flask-and-d3-js-7652a3647ee4
 - https://towardsdatascience.com/build-interactive-charts-using-flask-and-d3-js-70f715a76f93/
+
+
+## Extra Notes
+Right now, the old site is accessible at:
+- http://tech4taxes.org
+- http://tech4taxes.cntrl.site
+
+Right now, the new site is accessible at:
+- http://tech4taxes.duckdns.org

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  nginx-proxy:
+    image: jwilder/nginx-proxy
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+
+  t1t:
+    image: tech4taxes-website
+    ulimits:
+      nofile:
+        soft: 1000  # Soft limit for open file descriptors
+        hard: 2000  # Hard limit for open file descriptors
+    ports:
+      - "8000"
+    environment:
+      VIRTUAL_HOST: tech4taxes.duckdns.org

--- a/flask/.gitignore
+++ b/flask/.gitignore
@@ -1,2 +1,0 @@
-# Created by venv; see https://docs.python.org/3/library/venv.html
-*

--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,0 +1,21 @@
+# Use the official Python 3.8 slim image as the base image
+FROM python:3.12-slim
+
+# Set the working directory within the container
+WORKDIR /api-flask
+
+# Copy the necessary files and directories into the container
+ADD . /api-flask/
+
+RUN apt update
+RUN apt install -y uwsgi libexpat1
+
+# Upgrade pip and install Python dependencies
+RUN pip3 install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+
+# Expose port 8000 for the Flask application
+EXPOSE 8000
+
+# Define the command to run the Flask application using uWSGI
+CMD ["uwsgi", "--http", "0.0.0.0:8000", "-p", "1", "--master", "-w", "website:app"]

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -1,8 +1,8 @@
-blinker==1.9.0
-click==8.3.0
-Flask==3.1.2
-itsdangerous==2.2.0
-Jinja2==3.1.6
-MarkupSafe==3.0.3
-pyuwsgi==2.0.30
-Werkzeug==3.1.3
+blinker>=1.8.0
+click>=8.1.8
+Flask>=3.0.3
+itsdangerous>=2.2.0
+Jinja2>=3.1.6
+MarkupSafe>=2.1.5
+pyuwsgi>=2.0.30
+Werkzeug>=3.0.6


### PR DESCRIPTION
These changes are what it took to get the http-only nginx proxy running on porygon (eg. the DO server).

The duckdns is a necessary evil here esp. while we don't have a good answer re: squarespace/control DNS records/fowarding.

But what it does mean is that we have I guess 2 http sites up, and that's cool!

Old site:
https://tech4taxes.org
New site:
http://tech4taxes.duckdns.org

Theoretically, I'll be happy to change the forwarding in squarespace to use the duckdns address instead of control once we have HTTPS working on the new site (eg. letsencrypt & ssl for docker setup all that).


Anyways!

Of note, since my little old laptop doesn't run docker, I actually did all thsi dev directly on porygon, which is probably pretty naughty.

But also it means I actually set up an ssh key and a separate user for myself (even though god it's annoying to have to copy/paste a random long password from lastpass every single time I run a docker command.)