### PR TITLE
[docker] Add letsencrypt for ssl to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,26 @@ services:
     image: jwilder/nginx-proxy
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
+      - certs:/etc/nginx/certs
+      - html:/usr/share/nginx/html
+    labels:
+      - "com.github.nginx-proxy.nginx"
+
+  acme-companion:
+    image: nginxproxy/acme-companion
+    volumes:
+      - certs:/etc/nginx/certs
+      - html:/usr/share/nginx/html
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - acme:/etc/acme.sh
+    environment:
+      DEFAULT_EMAIL: tech4taxes@gmail.com
+    depends_on:
+      - "nginx-proxy"
+
 
   t1t:
     image: tech4taxes-website
@@ -16,3 +34,12 @@ services:
       - "8000"
     environment:
       VIRTUAL_HOST: tech4taxes.duckdns.org
+      LETSENCRYPT_HOST: tech4taxes.duckdns.org
+      LETSENCRYPT_EMAIL: tech4taxes@gmail.com
+    depends_on:
+      - "acme-companion"
+
+volumes:
+  certs:
+  html:
+  acme:


### PR DESCRIPTION
Wow. OK so it took a few attempts (like 3-4) but it actually did work after the like Nth time!

I was following the docker logs on the companion container and it really did eventually work. Not exciting to read asa pull request description but I assure you it was exciting as an experience.

Anyways, so this is a canonical PR but no exciting new functionality from a code perspective.

Also this docker compose is what's running now, on https://tech4taxes.duckdns.org - which is live!