### PR TITLE
Add ghcr.io cleanup step to container deploy workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -66,3 +66,7 @@ jobs:
           mode: compose
           detach: true
           args: --pull always --remove-orphans --force-recreate
+      - name: 'GHCR.io Container Version Cleanup'
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          keep-n-tagged: 5


### PR DESCRIPTION
Lets get this cleanup going. I think all these packages are labeled in CI and really we oughtnt to be building the pakcages anywho else.