### PR TITLE
Use base html templating to get favicon, base style, header, footer on all pages

### DIFF
--- a/flask/static/styles/website.css
+++ b/flask/static/styles/website.css
@@ -68,7 +68,7 @@ body {
     margin: 0; 
     line-height: 1; 
     text-transform: uppercase;
-    letter-spacing: 3;
+    letter-spacing: 3px;
 }
 
 /* Ensure the body content starts below the header */

--- a/flask/templates/base.html.jinja
+++ b/flask/templates/base.html.jinja
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<head>
+	<title>{% block title %}Tech4Taxes{% endblock %}</title>
+  <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
+
+	{% if config["VITE_DEV_SERVER"] is not none %}
+		<!-- Include the Vite dev server module -->
+		<script type="module" src="{{ config['VITE_DEV_SERVER'] }}/@vite/client"></script>
+	{% endif %}
+
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+	<link href="https://fonts.cdnfonts.com/css/reglo" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300..900;1,300..900&display=swap" rel="stylesheet">
+	<link rel="stylesheet" type="text/css" href={{ url_for('static', filename='styles/website.css') }} media="screen" />
+
+  {% block posthead %}{% endblock %}
+
+</head>
+
+<body>
+<header class="page-header"><img src={{ url_for('static', filename="assets/images/lb_orange.png") }} alt="Load Balancer Icon" class="logo-icon"><div class="logo-bar"><h1 class="logo-text">TECH 4 TAXES</h1></div></header>
+
+{% block content %}{% endblock %}
+
+</body>
+<footer>
+Connect with us!
+
+<div style="display: flex; flex-wrap: wrap; align-items: center; font-size: 14px;">
+    <a class="foota" href="https://www.tiktok.com/@tech4taxes7" target="_blank" rel="noopener noreferrer">TikTok</a>
+    <span style="margin-right: 16px;">|</span>
+    <a class="foota" href="https://www.instagram.com/tech4taxes" target="_blank" rel="noopener noreferrer">Instagram</a>
+    <span style="margin-right: 16px;">|</span>
+    <a class="foota" href="https://www.linkedin.com/company/107836109/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+</div>
+</footer>

--- a/flask/templates/datavis_demo.html
+++ b/flask/templates/datavis_demo.html
@@ -1,26 +1,10 @@
-<!DOCTYPE html>
-<head>
-	<title>Tech4Taxes</title>
+{% extends "base.html.jinja" %}
 
-	{% if config["VITE_DEV_SERVER"] is not none %}
-		<!-- Include the Vite dev server module -->
-		<script type="module" src="{{ config['VITE_DEV_SERVER'] }}/@vite/client"></script>
-	{% endif %}
+{% block posthead %}
+<script type="module" src="{{ get_module_path('demo') }}"></script>
+{% endblock %}
 
-	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-	<link href="https://fonts.cdnfonts.com/css/reglo" rel="stylesheet">
-	<link rel="stylesheet" type="text/css" href={{ url_for('static', filename='styles/website.css') }} media="screen" />
-
-	<!-- Include the bundled JavaScript at the end of the document -->
-	<script type="module" src="{{ get_module_path('demo') }}"></script>
-</head>
-
-<body>
-	<h1> A really cool demo data visualization should go here. </h1>
-
+{% block content %}
+<h1> A really cool demo data visualization should go here. </h1>
 <div id="container"></div>
-
-
-</body>
+{% endblock %}

--- a/flask/templates/footer.html.jinja
+++ b/flask/templates/footer.html.jinja
@@ -1,0 +1,11 @@
+<footer>
+Connect with us!
+
+<div style="display: flex; flex-wrap: wrap; align-items: center; font-size: 14px;">
+    <a class="foota" href="https://www.tiktok.com/@tech4taxes7" target="_blank" rel="noopener noreferrer">TikTok</a>
+    <span style="margin-right: 16px;">|</span>
+    <a class="foota" href="https://www.instagram.com/tech4taxes" target="_blank" rel="noopener noreferrer">Instagram</a>
+    <span style="margin-right: 16px;">|</span>
+    <a class="foota" href="https://www.linkedin.com/company/107836109/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+</div>
+</footer>

--- a/flask/templates/home.html
+++ b/flask/templates/home.html
@@ -1,23 +1,6 @@
-<head>
-	<title>Tech4Taxes</title>
-    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
+{% extends "base.html.jinja" %}
 
-	{% if config["VITE_DEV_SERVER"] is not none %}
-		<!-- Include the Vite dev server module -->
-		<script type="module" src="{{ config['VITE_DEV_SERVER'] }}/@vite/client"></script>
-	{% endif %}
-
-	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-	<link href="https://fonts.cdnfonts.com/css/reglo" rel="stylesheet">
-	<link href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300..900;1,300..900&display=swap" rel="stylesheet">
-	<link rel="stylesheet" type="text/css" href={{ url_for('static', filename='styles/website.css') }} media="screen" />
-
-</head>
-
-<body>
-<header class="page-header"><img src={{ url_for('static', filename="assets/images/lb_orange.png") }} alt="Load Balancer Icon" class="logo-icon"><div class="logo-bar"><h1 class="logo-text">TECH 4 TAXES</h1></div></header>
+{% block content %}
 <main>
 <p>
 Washington's tax code is upside-down. Washingtonians with a yearly income under $33.5k are paying over 13% of their income in taxes - and those with over $878k in yearly income are paying only 4.1% of theirs. With the current threats from the federal government, it is more important than ever that we create some truly progressive revenue in Washington state, to close the gap in our state's budget. In the 2025 legislative session, Big Tech and other mega-corporations lobbied hard against progressive revenue options.
@@ -37,15 +20,4 @@ Show lawmakers that tech workers love Washington State, and we want to see it th
 
 </p>
 </main>
-</body>
-<footer>
-Connect with us!
-
-<div style="display: flex; flex-wrap: wrap; align-items: center; font-size: 14px;">
-    <a class="foota" href="https://www.tiktok.com/@tech4taxes7" target="_blank" rel="noopener noreferrer">TikTok</a>
-    <span style="margin-right: 16px;">|</span>
-    <a class="foota" href="https://www.instagram.com/tech4taxes" target="_blank" rel="noopener noreferrer">Instagram</a>
-    <span style="margin-right: 16px;">|</span>
-    <a class="foota" href="https://www.linkedin.com/company/107836109/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-</div>
-</footer>
+{% endblock %}

--- a/flask/templates/legislative_agenda.html
+++ b/flask/templates/legislative_agenda.html
@@ -1,16 +1,7 @@
-<head>
-	<title>Legislative Agenda</title>
-    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
-	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-	<link href="https://fonts.cdnfonts.com/css/reglo" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300..900;1,300..900&display=swap" rel="stylesheet">
-	<link rel="stylesheet" type="text/css" href={{ url_for('static', filename='styles/website.css') }} media="screen" />
-</head>
-<body>
-<header class="page-header"><img src={{ url_for('static', filename="assets/images/lb_orange.png") }} alt="Load Balancer Icon" class="logo-icon"><div class="logo-bar"><h1 class="logo-text">TECH 4 TAXES</h1></div></header>
-<main style="margin: 0; 3vw;">
+{% extends "base.html.jinja" %}
+
+{% block content %}
+<main>
 <h1 style="border-bottom: 1px solid #e5e7eb;">
 2025-2026 Legislative Agenda</h1>
 <p class="longp" style="font-size: 2.5vw;">
@@ -81,15 +72,4 @@ Interested in helping us accomplish these goals? Fill out our <a href="https://f
 
 </p>
 </main>
-</body>
-<footer>
-Connect with us!
-
-<div style="display: flex; flex-wrap: wrap; align-items: center; font-size: 14px;">
-    <a class="foota" href="https://www.tiktok.com/@tech4taxes7" target="_blank" rel="noopener noreferrer">TikTok</a>
-    <span style="margin-right: 16px;">|</span>
-    <a class="foota" href="https://www.instagram.com/tech4taxes" target="_blank" rel="noopener noreferrer">Instagram</a>
-    <span style="margin-right: 16px;">|</span>
-    <a class="foota" href="https://www.linkedin.com/company/107836109/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-</div>
-</footer>
+{% endblock %}

--- a/flask/templates/logo_header.html.jinja
+++ b/flask/templates/logo_header.html.jinja
@@ -1,0 +1,1 @@
+<header class="page-header"><img src={{ url_for('static', filename="assets/images/lb_orange.png") }} alt="Load Balancer Icon" class="logo-icon"><div class="logo-bar"><h1 class="logo-text">TECH 4 TAXES</h1></div></header>

--- a/flask/vite-src/demo/index.ts
+++ b/flask/vite-src/demo/index.ts
@@ -2,7 +2,7 @@
 //
 import * as d3 from 'd3';
 
-var container = document.body;
+var container = document.getElementById("container");
 
 var rawData = `Ohh
 La la la la la
@@ -147,8 +147,8 @@ const y = d3.scaleLinear()
 
 // Create the SVG container.
 const svg = d3.create("svg")
-    .attr("width", width)
-    .attr("height", height);
+    .attr("viewBox", "0 0 " + width + " " + height)
+    .attr("preserveAspectRatio", "xMidYMid meet");
 
 // Add the x-axis.
 svg.append("g")
@@ -184,4 +184,3 @@ bars.selectAll('.bar')
 
 // Append the SVG element.
 container.append(svg.node());
-// container is null


### PR DESCRIPTION
This is kinda before doing any more JS or SCSS type of stuff.
The favicon and footer (and header) standardization can be achieved with this, so this seems like a legit way to do it.

Next up is to nice-ify the current datavis page with the actual benefits we get from typescript (and maybe c3 or plotly)