### PR TITLE
Change devserver js processor to use absolute paths

### DIFF
--- a/flask/templates/demo_d3.html
+++ b/flask/templates/demo_d3.html
@@ -1,7 +1,7 @@
 {% extends "base.html.jinja" %}
 
 {% block posthead %}
-<script type="module" src="{{ get_module_path('demo_d3') }}"></script>
+<script type="module" src="{{ get_module_path(request, 'demo_d3') }}"></script>
 {% endblock %}
 
 {% block content %}

--- a/flask/templates/demo_plotly.html
+++ b/flask/templates/demo_plotly.html
@@ -1,7 +1,7 @@
 {% extends "base.html.jinja" %}
 
 {% block posthead %}
-<script type="module" src="{{ get_module_path('demo_plotly') }}"></script>
+<script type="module" src="{{ get_module_path(request, 'demo_plotly') }}"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This should fix prod's imports for multiple depth routes (/demo/d3 , /demo/plotly) - when i say import, I mean JS imports.