### PR TITLE
fix vite warnings

### DIFF
--- a/flask/vite.config.js
+++ b/flask/vite.config.js
@@ -16,9 +16,7 @@ export default defineConfig({
                 file 
             ])),
             preserveEntrySignatures: "strict",
-            commonjsOptions: { transformMixedEsModules: true },
         },
-        outDir: "",
         emptyOutDir: false,
         assetsDir: "static/dist",
     },


### PR DESCRIPTION
Resolves #70

Fixes vite warnings related to invalid configuration options.

Also resolves this warning:

```
(!) build.outDir must not be the same directory of root or a parent directory of root as this could cause Vite to overwriting source files with build outputs.
```