### PR TITLE
Add semi-nice table to BNO demo page, with some column formatting. 

### DIFF
--- a/flask/vite-src/demo_bno/index.ts
+++ b/flask/vite-src/demo_bno/index.ts
@@ -93,10 +93,8 @@ dfd.readCSV("../../static/data/b_o_data.csv") //assumes file is in CWD
     const formatter = new Intl.NumberFormat('en-US', {
 	    style: 'currency',
 	    currency: 'USD',
-	    trailingZeroDisplay: "stripIfInteger"
     })
     // Table of raw data
-    const container3 = document.getElementById("container3");
     let rawdf = df.drop({columns: [""]}) // The index is straight up a column named ""
     rawdf.addColumn("CurrencyTaxable", rawdf.Taxable.apply(formatter.format), {inplace: true})
     rawdf.addColumn("CurrencyGrossRevenue", rawdf.GrossRevenue.apply(formatter.format), {inplace: true})
@@ -106,7 +104,7 @@ dfd.readCSV("../../static/data/b_o_data.csv") //assumes file is in CWD
     const botitle = "Washington State Department of Revenue B&O Quarterly Business Review 2025Q1"
 
     // "https://apps.dor.wa.gov/ResearchStats/Content/QuarterlyBusinessReview/Results5.aspx?Period=2025Q1&Type=naics&Format=HTML"
-    rawdf.plot(container3).table({layout: {title: botitle}, scrollZoom: true});
+    rawdf.plot("container3").table({layout: {title: botitle}});
 
   }).catch(err=>{
     console.log(err);


### PR DESCRIPTION
Note, should really be preprocessed in python code
(save the cpu cycles - do it once on the server rather than N times per client call.)

But w/e it's something!

The actual goal is to do a join on the NAICS values and clarify that.

Though I feel that probably formatting the tax paid as a proper percentage (is it 0.0001% or is it actually 0.001% because over 100 or whatever?) might be nice and clarifying as well.