### PR TITLE
docker-node: upgrade to node 26 and nvm 0.40.5

### DIFF
--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -11,7 +11,7 @@ RUN apt update
 RUN apt install -y curl
 
 # Install nvm / node / npm
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash && . "$HOME/.nvm/nvm.sh" && nvm install 22 && npm install && npm run build
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.5/install.sh | bash && . "$HOME/.nvm/nvm.sh" && nvm install 26 && npm install && npm run build
 
 # Upgrade pip and install Python dependencies
 RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
going to proc staging build and see if i broke everhting because it broke on my laptp...


```(flask) blitzle:flasknvm install 26
Downloading and installing node v26.3.0...
Downloading https://nodejs.org/dist/v26.3.0/node-v26.3.0-darwin-x64.tar.xz...
##################################################################################################################################################################################################### 100.0%
Computing checksum with sha256sum
Checksums matched!
Now using node v26.3.0
(flask) blitzle:flasknpm install
dyld[10042]: Symbol not found: (__ZNSt3__122__libcpp_verbose_abortEPKcz)
  Referenced from: '/Users/blitzle/.nvm/versions/node/v26.3.0/bin/node'
  Expected in: '/usr/lib/libc++.1.dylib'
Abort trap: 6
(flask) blitzle:flasknpm --version
dyld[10047]: Symbol not found: (__ZNSt3__122__libcpp_verbose_abortEPKcz)
  Referenced from: '/Users/blitzle/.nvm/versions/node/v26.3.0/bin/node'
  Expected in: '/usr/lib/libc++.1.dylib'
Abort trap: 6
```